### PR TITLE
LLReactiveMatchers: enforce class for sendError and sendValues.

### DIFF
--- a/LLReactiveMatchers/LLReactiveMatchersHelpers.h
+++ b/LLReactiveMatchers/LLReactiveMatchersHelpers.h
@@ -7,6 +7,8 @@ extern BOOL __attribute__((overloadable)) LLRMIdenticalValues(NSArray *left, NSA
 extern BOOL __attribute__((overloadable)) LLRMIdenticalValues(LLSignalTestRecorder *left, LLSignalTestRecorder *right);
 
 extern BOOL LLRMCorrectClassesForActual(id object);
+extern BOOL LLRMCorrectClassesForError(id object);
+extern BOOL LLRMCorrectClassesForValues(id object);
 extern LLSignalTestRecorder *LLRMRecorderForObject(id object);
 
 extern BOOL LLRMContainsAllValuesEqual(LLSignalTestRecorder *left, LLSignalTestRecorder *right);

--- a/LLReactiveMatchers/LLReactiveMatchersHelpers.m
+++ b/LLReactiveMatchers/LLReactiveMatchersHelpers.m
@@ -24,6 +24,14 @@ extern BOOL LLRMCorrectClassesForActual(id object) {
     return [object isKindOfClass:RACSignal.class] || [object isKindOfClass:LLSignalTestRecorder.class];
 }
 
+extern BOOL LLRMCorrectClassesForError(id object) {
+  return [object isKindOfClass:NSError.class];
+}
+
+extern BOOL LLRMCorrectClassesForValues(id object) {
+  return [object isKindOfClass:NSArray.class];
+}
+
 extern LLSignalTestRecorder *LLRMRecorderForObject(id object) {
     if([object isKindOfClass:LLSignalTestRecorder.class]) {
         return object;

--- a/LLReactiveMatchers/LLReactiveMatchersMessageBuilder.h
+++ b/LLReactiveMatchers/LLReactiveMatchersMessageBuilder.h
@@ -28,6 +28,7 @@
 - (NSString *) build;
 
 + (NSString *) actualNotCorrectClass:(id)actual;
++ (NSString *) expectedShouldBeOfClass:(Class)correctClass;
 + (NSString *) expectedNotCorrectClass:(id)expected;
 
 + (NSString *) actualNotFinished:(LLSignalTestRecorder *)actual;

--- a/LLReactiveMatchers/LLReactiveMatchersMessageBuilder.m
+++ b/LLReactiveMatchers/LLReactiveMatchersMessageBuilder.m
@@ -139,6 +139,10 @@ typedef NS_OPTIONS(NSUInteger, LLReactiveMatchersMessageBuilderRendering) {
     return [NSString stringWithFormat:@"expected: actual to be a signal or recorder: %@", actual];
 }
 
++ (NSString *) expectedShouldBeOfClass:(Class)correctClass {
+  return [NSString stringWithFormat:@"expected: expected to be of class %@", correctClass];
+}
+
 + (NSString *) expectedNotCorrectClass:(id)expected {
     return [NSString stringWithFormat:@"expected: expected to be a signal or recorder: %@",
             expected];

--- a/LLReactiveMatchers/Matchers/EXPMatchers+sendError.h
+++ b/LLReactiveMatchers/Matchers/EXPMatchers+sendError.h
@@ -1,3 +1,3 @@
 #import <Expecta/Expecta.h>
 
-EXPMatcherInterface(sendError, (id expected))
+EXPMatcherInterface(sendError, (NSError *expected))

--- a/LLReactiveMatchers/Matchers/EXPMatchers+sendError.m
+++ b/LLReactiveMatchers/Matchers/EXPMatchers+sendError.m
@@ -4,7 +4,7 @@
 #import "LLReactiveMatchersMessageBuilder.h"
 #import "LLReactiveMatchersHelpers.h"
 
-EXPMatcherImplementationBegin(sendError, (id expected))
+EXPMatcherImplementationBegin(sendError, (NSError *expected))
 
 __block LLSignalTestRecorder *actualRecorder = nil;
 __block LLSignalTestRecorder *expectedRecorder = nil;

--- a/LLReactiveMatchers/Matchers/EXPMatchers+sendError.m
+++ b/LLReactiveMatchers/Matchers/EXPMatchers+sendError.m
@@ -19,7 +19,7 @@ void (^subscribe)() = ^{
 };
 
 prerequisite(^BOOL{
-    return LLRMCorrectClassesForActual(actual);
+    return LLRMCorrectClassesForActual(actual) && LLRMCorrectClassesForError(expected);
 });
 
 match(^BOOL{
@@ -30,6 +30,9 @@ match(^BOOL{
 failureMessageForTo(^NSString *{
     if(!LLRMCorrectClassesForActual(actual)) {
         return [LLReactiveMatchersMessageBuilder actualNotCorrectClass:actual];
+    }
+    if(!LLRMCorrectClassesForError(expected)) {
+      return [LLReactiveMatchersMessageBuilder expectedShouldBeOfClass:NSError.class];
     }
     if(!(actualRecorder.hasCompleted || actualRecorder.hasErrored)) {
         return [LLReactiveMatchersMessageBuilder actualNotFinished:actualRecorder];

--- a/LLReactiveMatchers/Matchers/EXPMatchers+sendValues.h
+++ b/LLReactiveMatchers/Matchers/EXPMatchers+sendValues.h
@@ -1,3 +1,3 @@
 #import <Expecta/Expecta.h>
 
-EXPMatcherInterface(sendValues, (id expected))
+EXPMatcherInterface(sendValues, (NSArray *expected))

--- a/LLReactiveMatchers/Matchers/EXPMatchers+sendValues.m
+++ b/LLReactiveMatchers/Matchers/EXPMatchers+sendValues.m
@@ -5,7 +5,7 @@
 #import "LLReactiveMatchersHelpers.h"
 #import "LLSignalTestRecorder.h"
 
-EXPMatcherImplementationBegin(sendValues, (id expected))
+EXPMatcherImplementationBegin(sendValues, (NSArray *expected))
 
 __block LLSignalTestRecorder *actualRecorder = nil;
 __block LLSignalTestRecorder *expectedRecorder = nil;

--- a/LLReactiveMatchers/Matchers/EXPMatchers+sendValues.m
+++ b/LLReactiveMatchers/Matchers/EXPMatchers+sendValues.m
@@ -20,7 +20,7 @@ void (^subscribe)(void) = ^{
 };
 
 prerequisite(^BOOL{
-    return LLRMCorrectClassesForActual(actual);
+    return LLRMCorrectClassesForActual(actual) && LLRMCorrectClassesForValues(expected);
 });
 
 match(^BOOL{
@@ -32,7 +32,10 @@ failureMessageForTo(^NSString *{
     if(!LLRMCorrectClassesForActual(actual)) {
         return [LLReactiveMatchersMessageBuilder actualNotCorrectClass:actual];
     }
-    
+    if(!LLRMCorrectClassesForValues(expected)) {
+      return [LLReactiveMatchersMessageBuilder expectedShouldBeOfClass:NSArray.class];
+    }
+
     return [[[[[[LLReactiveMatchersMessageBuilder message] actual:actualRecorder] renderActualValues] expected:expectedRecorder] renderExpectedValues] build];
 });
 

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Occasionally, you may need to make assertions about the number of subscriptions 
     expect(signal).to.matchError(matchBlock); //Succeeds if 'matchBlock' returns YES from 'matchBlock' provided.
     expect(signal).to.matchValue(matchIndex, matchBlock); //Succeeds if 'matchBlock' returns YES from 'matchIndex' provided.
     expect(signal).to.matchValues(matchBlock);  //Succeeds if 'matchBlock' returns YES for all values that 'signal' sends.
-    expect(signal).to.sendError(expectedError);  //Succeeds if 'signal' sends an error that is equal to 'expectedError'. 'expectedError' can be an NSError, RACSignal or LLSignalTestRecorder.
+    expect(signal).to.sendError(expectedError);  //Succeeds if 'signal' sends an error that is equal to 'expectedError'. 'expectedError' must be an NSError.
     expect(signal).to.sendEvents(expectedEvents);  //Succeeds if 'signal' and 'expectedSignal' send exactly the same events including next values. 'expectedEvents' can be a RACSignal or LLSignalTestRecorder.
     expect(signal).to.sendValue(matchIndex, expectedValue);  //Succeeds if 'signal' sends 'expectedValue' at 'matchIndex'.
-    expect(signal).to.sendValues(expectedValues);  //Succeeds if 'signal' exactly sends all of the values in 'expectedValues' and then finishes. 'expectedValues' can be a RACSignal, LLSignalTestRecorder or an NSArray of expected values. 
+    expect(signal).to.sendValues(expectedValues);  //Succeeds if 'signal' exactly sends all of the values in 'expectedValues' and then finishes. 'expectedValues' must be an NSArray of expected values. 
     expect(signal).to.sendValuesWithCount(expectedCount);  //Succeeds if 'signal' sends exactly the number of events of 'expectedCounts', waits for 'signal' to finish.
 ```
 


### PR DESCRIPTION
So there will be compile time error if the values passed to the `sendError` and `sendValues` matchers are not of the right class.