### PR TITLE
NSObject+RACPropertySubscribing: Remove pragma that causes a warning.

### DIFF
--- a/Pods/ReactiveCocoa/ReactiveCocoa/NSObject+RACPropertySubscribing.h
+++ b/Pods/ReactiveCocoa/ReactiveCocoa/NSObject+RACPropertySubscribing.h
@@ -48,11 +48,8 @@
 /// completed if self or observer is deallocated.
 #define RACObserve(TARGET, KEYPATH) \
 	({ \
-		_Pragma("clang diagnostic push") \
-		_Pragma("clang diagnostic ignored \"-Wreceiver-is-weak\"") \
 		__weak id target_ = (TARGET); \
 		[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
-		_Pragma("clang diagnostic pop") \
 	})
 
 @class RACDisposable;


### PR DESCRIPTION
@StatusReport / @barakyoresh 